### PR TITLE
Add setup.py so we're pip installable.

### DIFF
--- a/allennlp_semparse/version.py
+++ b/allennlp_semparse/version.py
@@ -1,0 +1,6 @@
+_MAJOR = "0"
+_MINOR = "0"
+_REVISION = "1-unreleased"
+
+VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
+VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # To be changed to allennlp>=1.0 once that's released.
-# TODO: When this occurs, modify setup.py to 1) not exclude this line and
-# conditionally filter the standard allenlp version instead, 2) remove the fake
-# allennlp version from install_requirements and 3) remove the dependency_links
-# section.
+# TODO: When this occurs, modify setup.py to 1) not exclude this line, 2)
+# conditionally filter the standard allenlp version instead, and 3) stop adding
+# the git url for allennlp to install_requirements.
 git+git://github.com/allenai/allennlp@93024e53c1445cb4630ee5c07926abff8943715f
 
 # Used to create grammars for parsing SQL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
 # To be changed to allennlp>=1.0 once that's released.
+# TODO: When this occurs, modify setup.py to 1) not exclude this line and
+# conditionally filter the standard allenlp version instead, 2) remove the fake
+# allennlp version from install_requirements and 3) remove the dependency_links
+# section.
 git+git://github.com/allenai/allennlp@93024e53c1445cb4630ee5c07926abff8943715f
 
 # Used to create grammars for parsing SQL

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,72 @@
+from setuptools import setup, find_packages
+import sys
+import os
+
+# PEP0440 compatible formatted version, see:
+# https://www.python.org/dev/peps/pep-0440/
+#
+# release markers:
+#   X.Y
+#   X.Y.Z   # For bugfix releases
+#
+# pre-release markers:
+#   X.YaN   # Alpha release
+#   X.YbN   # Beta release
+#   X.YrcN  # Release Candidate
+#   X.Y     # Final release
+
+# version.py defines the VERSION and VERSION_SHORT variables.
+# We use exec here so we don't import allennlp_semparse whilst setting up.
+VERSION = {}
+with open("allennlp_semparse/version.py") as version_file:
+    exec(version_file.read(), VERSION)
+
+# Load requirements.txt with a special case for allennlp so we can handle
+# cross-library integration testing.
+with open("requirements.txt") as requirements_file:
+    install_requirements = requirements_file.readlines()
+    install_requirements = [
+        r for r in install_requirements if "git+git://github.com/allenai/allennlp" not in r
+    ]
+    if "EXCLUDE_ALLENNLP_IN_SETUP" not in os.environ:
+        #dependency_links=["http://github.com/allenai/allennlp/tarball/93024e53c1445cb4630ee5c07926abff8943715f#egg={FAKE_VERSION}"],
+        #requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@v1.1#egg=some-pkg"
+        requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@93024e53c1445cb4630ee5c07926abff8943715f#egg=allennlp"
+        requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@457a85bde57ba58289d32e4e1d07df1f94c813b0#egg=allennlp"
+        install_requirements.append(requirement)
+
+# make pytest-runner a conditional requirement,
+# per: https://github.com/pytest-dev/pytest-runner#considerations
+needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
+pytest_runner = ["pytest-runner"] if needs_pytest else []
+
+setup_requirements = [
+    # add other setup requirements as necessary
+] + pytest_runner
+
+setup(
+    name="allennlp_semparse",
+    version=VERSION["VERSION"],
+    description="A framework for building semantic parsers (including neural module networks) with AllenNLP, built by the authors of AllenNLP",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    ],
+    keywords="allennlp NLP deep learning machine reading semantic parsing parsers",
+    url="https://github.com/allenai/allennlp-semparse",
+    author="Allen Institute for Artificial Intelligence",
+    author_email="allennlp@allenai.org",
+    license="Apache",
+    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    install_requires=install_requirements,
+    setup_requires=setup_requirements,
+    tests_require=["pytest", "flaky", "responses>=0.7"],
+    include_package_data=True,
+    python_requires=">=3.6.1",
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,18 @@ with open("requirements.txt") as requirements_file:
         r for r in install_requirements if "git+git://github.com/allenai/allennlp" not in r
     ]
     if "EXCLUDE_ALLENNLP_IN_SETUP" not in os.environ:
-        #dependency_links=["http://github.com/allenai/allennlp/tarball/93024e53c1445cb4630ee5c07926abff8943715f#egg={FAKE_VERSION}"],
-        #requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@v1.1#egg=some-pkg"
-        requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@93024e53c1445cb4630ee5c07926abff8943715f#egg=allennlp"
-        requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@457a85bde57ba58289d32e4e1d07df1f94c813b0#egg=allennlp"
+        # Warning: This will not give you the desired version if you've already
+        # installed allennlp! See https://github.com/pypa/pip/issues/5898.
+        #
+        # There used to be an alternative to this using `dependency_links`
+        # (https://stackoverflow.com/questions/3472430), but pip decided to
+        # remove this in version 19 breaking numerous projects in the process.
+        # See https://github.com/pypa/pip/issues/6162.
+        #
+        # As a mitigation, run `pip uninstall allennlp` before installing this
+        # package.
+        sha = "93024e53c1445cb4630ee5c07926abff8943715f"
+        requirement = f"allennlp @ git+ssh://git@github.com/allenai/allennlp@{sha}#egg=allennlp"
         install_requirements.append(requirement)
 
 # make pytest-runner a conditional requirement,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("requirements.txt") as requirements_file:
     install_requirements = [
         r for r in install_requirements if "git+git://github.com/allenai/allennlp" not in r
     ]
-    if os.environ.get("EXCLUDE_ALLENNLP_IN_SETUP"):
+    if not os.environ.get("EXCLUDE_ALLENNLP_IN_SETUP"):
         # Warning: This will not give you the desired version if you've already
         # installed allennlp! See https://github.com/pypa/pip/issues/5898.
         #

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,10 @@ setup_requirements = [
 setup(
     name="allennlp_semparse",
     version=VERSION["VERSION"],
-    description=("A framework for building semantic parsers (including neural "
-    "module networks) with AllenNLP, built by the authors of AllenNLP"),
+    description=(
+        "A framework for building semantic parsers (including neural "
+        "module networks) with AllenNLP, built by the authors of AllenNLP"
+    ),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("requirements.txt") as requirements_file:
     install_requirements = [
         r for r in install_requirements if "git+git://github.com/allenai/allennlp" not in r
     ]
-    if "EXCLUDE_ALLENNLP_IN_SETUP" not in os.environ:
+    if os.environ.get("EXCLUDE_ALLENNLP_IN_SETUP"):
         # Warning: This will not give you the desired version if you've already
         # installed allennlp! See https://github.com/pypa/pip/issues/5898.
         #

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,8 @@ setup_requirements = [
 setup(
     name="allennlp_semparse",
     version=VERSION["VERSION"],
-    description="A framework for building semantic parsers (including neural module networks) with AllenNLP, built by the authors of AllenNLP",
+    description=("A framework for building semantic parsers (including neural "
+    "module networks) with AllenNLP, built by the authors of AllenNLP"),
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
     classifiers=[


### PR DESCRIPTION
- IIUC, this is most of what's needed to make a formal release, but I haven't tested that. Local-only so far.
- Installing dependencies that aren't on pypi proved clunkier than expected.
  - For now I'm going to set the CI to manually run `pip install --editable allennlp` for on a local checkout.
  - The allennlp specified in `setup.py` will be excluded with an environment variable.
- Prereq for https://github.com/allenai/allennlp/issues/3351.