### PR TITLE
Fix breakage from removing WordSplitter.

### DIFF
--- a/allennlp_semparse/dataset_readers/atis.py
+++ b/allennlp_semparse/dataset_readers/atis.py
@@ -11,8 +11,7 @@ from allennlp.data import DatasetReader
 from allennlp.data.fields import Field, ArrayField, ListField, IndexField, TextField, MetadataField
 from allennlp.data.instance import Instance
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenIndexer
-from allennlp.data.tokenizers import Tokenizer, WordTokenizer
-from allennlp.data.tokenizers.word_splitter import SpacyWordSplitter
+from allennlp.data.tokenizers import Tokenizer, SpacyTokenizer
 
 from allennlp_semparse.fields import ProductionRuleField
 from allennlp_semparse.parsimonious_languages.worlds.atis_world import AtisWorld
@@ -64,7 +63,7 @@ class AtisDatasetReader(DatasetReader):
         Passed to ``DatasetReader``.  If this is ``True``, training will start sooner, but will
         take longer per batch.
     tokenizer : ``Tokenizer``, optional
-        Tokenizer to use for the utterances. Will default to ``WordTokenizer()`` with Spacy's tagger
+        Tokenizer to use for the utterances. Will default to ``SpacyTokenizer()`` with Spacy's tagger
         enabled.
     database_file: ``str``, optional
         The directory to find the sqlite database file. We query the sqlite database to find the strings
@@ -85,7 +84,7 @@ class AtisDatasetReader(DatasetReader):
         super().__init__(lazy)
         self._keep_if_unparseable = keep_if_unparseable
         self._token_indexers = token_indexers or {"tokens": SingleIdTokenIndexer()}
-        self._tokenizer = tokenizer or WordTokenizer(SpacyWordSplitter())
+        self._tokenizer = tokenizer or SpacyTokenizer()
         self._database_file = database_file
         self._num_turns_to_concatenate = num_turns_to_concatenate
 

--- a/allennlp_semparse/dataset_readers/nlvr.py
+++ b/allennlp_semparse/dataset_readers/nlvr.py
@@ -9,7 +9,7 @@ from allennlp.data import DatasetReader
 from allennlp.data.fields import Field, TextField, ListField, IndexField, LabelField, MetadataField
 from allennlp.data.instance import Instance
 from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
-from allennlp.data.tokenizers import Tokenizer, WordTokenizer
+from allennlp.data.tokenizers import Tokenizer, SpacyTokenizer
 
 from allennlp_semparse.domain_languages import NlvrLanguage
 from allennlp_semparse.domain_languages.nlvr_language import Box
@@ -64,7 +64,7 @@ class NlvrDatasetReader(DatasetReader):
         Passed to ``DatasetReader``.  If this is ``True``, training will start sooner, but will
         take longer per batch.
     tokenizer : ``Tokenizer`` (optional)
-        The tokenizer used for sentences in NLVR. Default is ``WordTokenizer``
+        The tokenizer used for sentences in NLVR. Default is ``SpacyTokenizer``
     sentence_token_indexers : ``Dict[str, TokenIndexer]`` (optional)
         Token indexers for tokens in input sentences.
         Default is ``{"tokens": SingleIdTokenIndexer()}``
@@ -91,7 +91,7 @@ class NlvrDatasetReader(DatasetReader):
         output_agendas: bool = True,
     ) -> None:
         super().__init__(lazy)
-        self._tokenizer = tokenizer or WordTokenizer()
+        self._tokenizer = tokenizer or SpacyTokenizer()
         self._sentence_token_indexers = sentence_token_indexers or {
             "tokens": SingleIdTokenIndexer()
         }

--- a/allennlp_semparse/dataset_readers/quarel.py
+++ b/allennlp_semparse/dataset_readers/quarel.py
@@ -2,14 +2,13 @@
 Reader for QuaRel dataset
 """
 
+from nltk.stem import PorterStemmer as NltkPorterStemmer
+from overrides import overrides
 from typing import Any, Dict, List, Optional, Tuple, Union
 import json
 import logging
-import re
-
 import numpy as np
-from overrides import overrides
-
+import re
 import tqdm
 
 from allennlp.common.file_utils import cached_path
@@ -19,8 +18,7 @@ from allennlp.data.fields import ArrayField, Field, TextField, LabelField
 from allennlp.data.fields import IndexField, ListField, MetadataField, SequenceLabelField
 from allennlp.data.instance import Instance
 from allennlp.data.token_indexers import TokenIndexer, SingleIdTokenIndexer
-from allennlp.data.tokenizers import Token, Tokenizer, WordTokenizer
-from allennlp.data.tokenizers.word_stemmer import PorterStemmer
+from allennlp.data.tokenizers import Token, Tokenizer, SpacyTokenizer
 
 from allennlp_semparse.common.knowledge_graph import KnowledgeGraph
 from allennlp_semparse.fields import KnowledgeGraphField, ProductionRuleField
@@ -89,7 +87,7 @@ class QuarelDatasetReader(DatasetReader):
         question_token_indexers: Dict[str, TokenIndexer] = None,
     ) -> None:
         super().__init__(lazy=lazy)
-        self._tokenizer = tokenizer or WordTokenizer()
+        self._tokenizer = tokenizer or SpacyTokenizer()
         self._question_token_indexers = question_token_indexers or {
             "tokens": SingleIdTokenIndexer()
         }
@@ -162,7 +160,7 @@ class QuarelDatasetReader(DatasetReader):
             )
             self._world = QuarelWorld(self._knowledge_graph, self._lf_syntax)
 
-        self._stemmer = PorterStemmer().stemmer
+        self._stemmer = NltkPorterStemmer()
 
         self._world_tagger_extractor = None
         self._extract_worlds = False

--- a/allennlp_semparse/dataset_readers/wikitables.py
+++ b/allennlp_semparse/dataset_readers/wikitables.py
@@ -15,9 +15,8 @@ from allennlp.data.fields import Field, TextField, MetadataField, ListField, Ind
 from allennlp.data.instance import Instance
 from allennlp.data.token_indexers import SingleIdTokenIndexer
 from allennlp.data.token_indexers.token_indexer import TokenIndexer
-from allennlp.data.tokenizers import WordTokenizer
+from allennlp.data.tokenizers import SpacyTokenizer
 from allennlp.data.tokenizers.tokenizer import Tokenizer
-from allennlp.data.tokenizers.word_splitter import SpacyWordSplitter
 
 from allennlp_semparse.common import ParsingError
 from allennlp_semparse.common.wikitables import TableQuestionContext
@@ -102,7 +101,7 @@ class WikiTablesDatasetReader(DatasetReader):
         Otherwise, your accuracy numbers will only reflect the subset of the data that has offline search
         output.
     tokenizer : ``Tokenizer``, optional
-        Tokenizer to use for the questions. Will default to ``WordTokenizer()`` with Spacy's tagger
+        Tokenizer to use for the questions. Will default to ``SpacyTokenizer()`` with Spacy's tagger
         enabled, as we use lemma matches as features for entity linking.
     question_token_indexers : ``Dict[str, TokenIndexer]``, optional
         Token indexers for questions. Will default to ``{"tokens": SingleIdTokenIndexer()}``.
@@ -143,7 +142,7 @@ class WikiTablesDatasetReader(DatasetReader):
         self._offline_logical_forms_directory = offline_logical_forms_directory
         self._max_offline_logical_forms = max_offline_logical_forms
         self._keep_if_no_logical_forms = keep_if_no_logical_forms
-        self._tokenizer = tokenizer or WordTokenizer(SpacyWordSplitter(pos_tags=True))
+        self._tokenizer = tokenizer or SpacyTokenizer(pos_tags=True)
         self._question_token_indexers = question_token_indexers or {
             "tokens": SingleIdTokenIndexer()
         }

--- a/allennlp_semparse/fields/knowledge_graph_field.py
+++ b/allennlp_semparse/fields/knowledge_graph_field.py
@@ -12,9 +12,8 @@ from allennlp.common import util
 from allennlp.common.checks import ConfigurationError
 from allennlp.data.fields.field import Field
 from allennlp.data.token_indexers.token_indexer import TokenIndexer, TokenType
-from allennlp.data.tokenizers.word_splitter import SpacyWordSplitter
 from allennlp.data.tokenizers.token import Token
-from allennlp.data.tokenizers import Tokenizer, WordTokenizer
+from allennlp.data.tokenizers import Tokenizer, SpacyTokenizer
 from allennlp.data.vocabulary import Vocabulary
 from allennlp.nn import util as nn_util
 
@@ -54,7 +53,7 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
     utterance_tokens : ``List[Token]``
         The tokens in some utterance that is paired with the ``KnowledgeGraph``.  We compute a set
         of features for linking tokens in the utterance to entities in the graph.
-    tokenizer : ``Tokenizer``, optional (default=``WordTokenizer()``)
+    tokenizer : ``Tokenizer``, optional (default=``SpacyTokenizer()``)
         We'll use this ``Tokenizer`` to tokenize the text representation of each entity.
     token_indexers : ``Dict[str, TokenIndexer]``
         Token indexers that convert entities into arrays, similar to how text tokens are treated in
@@ -100,7 +99,7 @@ class KnowledgeGraphField(Field[Dict[str, torch.Tensor]]):
     ) -> None:
 
         self.knowledge_graph = knowledge_graph
-        self._tokenizer = tokenizer or WordTokenizer(word_splitter=SpacyWordSplitter(pos_tags=True))
+        self._tokenizer = tokenizer or SpacyTokenizer(pos_tags=True)
         if not entity_tokens:
             entity_texts = [
                 knowledge_graph.entity_text[entity].lower() for entity in knowledge_graph.entities

--- a/allennlp_semparse/parsimonious_languages/worlds/atis_world.py
+++ b/allennlp_semparse/parsimonious_languages/worlds/atis_world.py
@@ -7,7 +7,7 @@ from nltk import ngrams, bigrams
 from parsimonious.grammar import Grammar
 from parsimonious.expressions import Expression, OneOf, Sequence, Literal
 
-from allennlp.data.tokenizers import Token, Tokenizer, WordTokenizer
+from allennlp.data.tokenizers import Token, Tokenizer, SpacyTokenizer
 
 from allennlp_semparse.parsimonious_languages.contexts import atis_tables
 from allennlp_semparse.parsimonious_languages.contexts.atis_sql_table_context import (
@@ -59,7 +59,7 @@ class AtisWorld:
     utterances: ``List[str]``
         A list of utterances in the interaction, the last element in this list is the
         current utterance that we are interested in.
-    tokenizer: ``Tokenizer``, optional (default=``WordTokenizer()``)
+    tokenizer: ``Tokenizer``, optional (default=``SpacyTokenizer()``)
         We use this tokenizer to tokenize the utterances.
     """
 
@@ -72,7 +72,7 @@ class AtisWorld:
                 atis_tables.ALL_TABLES, atis_tables.TABLES_WITH_STRINGS, AtisWorld.database_file
             )
         self.utterances: List[str] = utterances
-        self.tokenizer = tokenizer if tokenizer else WordTokenizer()
+        self.tokenizer = tokenizer if tokenizer else SpacyTokenizer()
         self.tokenized_utterances = [
             self.tokenizer.tokenize(utterance) for utterance in self.utterances
         ]

--- a/allennlp_semparse/version.py
+++ b/allennlp_semparse/version.py
@@ -1,0 +1,6 @@
+_MAJOR = "0"
+_MINOR = "0"
+_REVISION = "1-unreleased"
+
+VERSION_SHORT = "{0}.{1}".format(_MAJOR, _MINOR)
+VERSION = "{0}.{1}.{2}".format(_MAJOR, _MINOR, _REVISION)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
 # To be changed to allennlp>=1.0 once that's released.
-# TODO: When this occurs, modify setup.py to 1) not exclude this line and
-# conditionally filter the standard allenlp version instead, 2) remove the fake
-# allennlp version from install_requirements and 3) remove the dependency_links
-# section.
+# TODO: When this occurs, modify setup.py to 1) not exclude this line, 2)
+# conditionally filter the standard allenlp version instead, and 3) stop adding
+# the git url for allennlp to install_requirements.
 git+git://github.com/allenai/allennlp@93024e53c1445cb4630ee5c07926abff8943715f
 
 # Used to create grammars for parsing SQL

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@
 # the git url for allennlp to install_requirements.
 git+git://github.com/allenai/allennlp@93024e53c1445cb4630ee5c07926abff8943715f
 
+nltk
+
 # Used to create grammars for parsing SQL
 parsimonious>=0.8.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,9 @@
 # TODO: When this occurs, modify setup.py to 1) not exclude this line, 2)
 # conditionally filter the standard allenlp version instead, and 3) stop adding
 # the git url for allennlp to install_requirements.
-git+git://github.com/allenai/allennlp@93024e53c1445cb4630ee5c07926abff8943715f
+git+git://github.com/allenai/allennlp@88fe0075c28babb20f076c43f932b77d80ce81a3
 
+# For PorterStemmer
 nltk
 
 # Used to create grammars for parsing SQL

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,8 @@
 # To be changed to allennlp>=1.0 once that's released.
+# TODO: When this occurs, modify setup.py to 1) not exclude this line and
+# conditionally filter the standard allenlp version instead, 2) remove the fake
+# allennlp version from install_requirements and 3) remove the dependency_links
+# section.
 git+git://github.com/allenai/allennlp@93024e53c1445cb4630ee5c07926abff8943715f
 
 # Used to create grammars for parsing SQL

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,72 @@
+from setuptools import setup, find_packages
+import sys
+import os
+
+# PEP0440 compatible formatted version, see:
+# https://www.python.org/dev/peps/pep-0440/
+#
+# release markers:
+#   X.Y
+#   X.Y.Z   # For bugfix releases
+#
+# pre-release markers:
+#   X.YaN   # Alpha release
+#   X.YbN   # Beta release
+#   X.YrcN  # Release Candidate
+#   X.Y     # Final release
+
+# version.py defines the VERSION and VERSION_SHORT variables.
+# We use exec here so we don't import allennlp_semparse whilst setting up.
+VERSION = {}
+with open("allennlp_semparse/version.py") as version_file:
+    exec(version_file.read(), VERSION)
+
+# Load requirements.txt with a special case for allennlp so we can handle
+# cross-library integration testing.
+with open("requirements.txt") as requirements_file:
+    install_requirements = requirements_file.readlines()
+    install_requirements = [
+        r for r in install_requirements if "git+git://github.com/allenai/allennlp" not in r
+    ]
+    if "EXCLUDE_ALLENNLP_IN_SETUP" not in os.environ:
+        #dependency_links=["http://github.com/allenai/allennlp/tarball/93024e53c1445cb4630ee5c07926abff8943715f#egg={FAKE_VERSION}"],
+        #requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@v1.1#egg=some-pkg"
+        requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@93024e53c1445cb4630ee5c07926abff8943715f#egg=allennlp"
+        requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@457a85bde57ba58289d32e4e1d07df1f94c813b0#egg=allennlp"
+        install_requirements.append(requirement)
+
+# make pytest-runner a conditional requirement,
+# per: https://github.com/pytest-dev/pytest-runner#considerations
+needs_pytest = {"pytest", "test", "ptr"}.intersection(sys.argv)
+pytest_runner = ["pytest-runner"] if needs_pytest else []
+
+setup_requirements = [
+    # add other setup requirements as necessary
+] + pytest_runner
+
+setup(
+    name="allennlp_semparse",
+    version=VERSION["VERSION"],
+    description="A framework for building semantic parsers (including neural module networks) with AllenNLP, built by the authors of AllenNLP",
+    long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
+    classifiers=[
+        "Intended Audience :: Science/Research",
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: Apache Software License",
+        "Programming Language :: Python :: 3.6",
+        "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    ],
+    keywords="allennlp NLP deep learning machine reading semantic parsing parsers",
+    url="https://github.com/allenai/allennlp-semparse",
+    author="Allen Institute for Artificial Intelligence",
+    author_email="allennlp@allenai.org",
+    license="Apache",
+    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests.*", "tests"]),
+    install_requires=install_requirements,
+    setup_requires=setup_requirements,
+    tests_require=["pytest", "flaky", "responses>=0.7"],
+    include_package_data=True,
+    python_requires=">=3.6.1",
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,18 @@ with open("requirements.txt") as requirements_file:
         r for r in install_requirements if "git+git://github.com/allenai/allennlp" not in r
     ]
     if "EXCLUDE_ALLENNLP_IN_SETUP" not in os.environ:
-        #dependency_links=["http://github.com/allenai/allennlp/tarball/93024e53c1445cb4630ee5c07926abff8943715f#egg={FAKE_VERSION}"],
-        #requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@v1.1#egg=some-pkg"
-        requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@93024e53c1445cb4630ee5c07926abff8943715f#egg=allennlp"
-        requirement = "allennlp @ git+ssh://git@github.com/allenai/allennlp@457a85bde57ba58289d32e4e1d07df1f94c813b0#egg=allennlp"
+        # Warning: This will not give you the desired version if you've already
+        # installed allennlp! See https://github.com/pypa/pip/issues/5898.
+        #
+        # There used to be an alternative to this using `dependency_links`
+        # (https://stackoverflow.com/questions/3472430), but pip decided to
+        # remove this in version 19 breaking numerous projects in the process.
+        # See https://github.com/pypa/pip/issues/6162.
+        #
+        # As a mitigation, run `pip uninstall allennlp` before installing this
+        # package.
+        sha = "93024e53c1445cb4630ee5c07926abff8943715f"
+        requirement = f"allennlp @ git+ssh://git@github.com/allenai/allennlp@{sha}#egg=allennlp"
         install_requirements.append(requirement)
 
 # make pytest-runner a conditional requirement,

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ with open("requirements.txt") as requirements_file:
         #
         # As a mitigation, run `pip uninstall allennlp` before installing this
         # package.
-        sha = "93024e53c1445cb4630ee5c07926abff8943715f"
+        sha = "88fe0075c28babb20f076c43f932b77d80ce81a3"
         requirement = f"allennlp @ git+ssh://git@github.com/allenai/allennlp@{sha}#egg=allennlp"
         install_requirements.append(requirement)
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open("requirements.txt") as requirements_file:
     install_requirements = [
         r for r in install_requirements if "git+git://github.com/allenai/allennlp" not in r
     ]
-    if "EXCLUDE_ALLENNLP_IN_SETUP" not in os.environ:
+    if os.environ.get("EXCLUDE_ALLENNLP_IN_SETUP"):
         # Warning: This will not give you the desired version if you've already
         # installed allennlp! See https://github.com/pypa/pip/issues/5898.
         #

--- a/tests/common/wikitables/table_question_context_test.py
+++ b/tests/common/wikitables/table_question_context_test.py
@@ -8,7 +8,7 @@ from allennlp_semparse.common.wikitables import TableQuestionContext
 class TestTableQuestionContext(SemparseTestCase):
     def setUp(self):
         super().setUp()
-        self.tokenizer = SpacyTokenizer()
+        self.tokenizer = SpacyTokenizer(pos_tags=True)
 
     def test_table_data(self):
         question = "what was the attendance when usl a league played?"

--- a/tests/common/wikitables/table_question_context_test.py
+++ b/tests/common/wikitables/table_question_context_test.py
@@ -1,6 +1,5 @@
 from ... import SemparseTestCase
-from allennlp.data.tokenizers import WordTokenizer
-from allennlp.data.tokenizers.word_splitter import SpacyWordSplitter
+from allennlp.data.tokenizers import SpacyTokenizer
 
 from allennlp_semparse.common import Date
 from allennlp_semparse.common.wikitables import TableQuestionContext
@@ -9,7 +8,7 @@ from allennlp_semparse.common.wikitables import TableQuestionContext
 class TestTableQuestionContext(SemparseTestCase):
     def setUp(self):
         super().setUp()
-        self.tokenizer = WordTokenizer(SpacyWordSplitter(pos_tags=True))
+        self.tokenizer = SpacyTokenizer()
 
     def test_table_data(self):
         question = "what was the attendance when usl a league played?"

--- a/tests/domain_languages/wikitables_language_test.py
+++ b/tests/domain_languages/wikitables_language_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from .. import SemparseTestCase
 from allennlp.data.tokenizers import Token
-from allennlp.data.tokenizers import WordTokenizer
+from allennlp.data.tokenizers import SpacyTokenizer
 
 from allennlp_semparse.common import Date, ExecutionError
 from allennlp_semparse.common.wikitables import TableQuestionContext
@@ -404,7 +404,7 @@ class TestWikiTablesLanguage(SemparseTestCase):
     def test_number_comparison_works(self):
         # TableQuestionContext normlaizes all strings according to some rules. We want to ensure
         # that the original numerical values of number cells is being correctly processed here.
-        tokens = WordTokenizer().tokenize("when was the attendance the highest?")
+        tokens = SpacyTokenizer().tokenize("when was the attendance the highest?")
         tagged_file = self.FIXTURES_ROOT / "data" / "corenlp_processed_tables" / "TEST-2.table"
         language = self._get_world_with_question_tokens_and_table_file(tokens, tagged_file)
         result = language.execute(

--- a/tests/fields/knowledge_graph_field_test.py
+++ b/tests/fields/knowledge_graph_field_test.py
@@ -15,7 +15,7 @@ from allennlp_semparse.fields import KnowledgeGraphField
 
 class KnowledgeGraphFieldTest(SemparseTestCase):
     def setUp(self):
-        self.tokenizer = SpacyTokenizer()
+        self.tokenizer = SpacyTokenizer(pos_tags=True)
         self.utterance = self.tokenizer.tokenize("where is mersin?")
         self.token_indexers = {"tokens": SingleIdTokenIndexer("tokens")}
 

--- a/tests/fields/knowledge_graph_field_test.py
+++ b/tests/fields/knowledge_graph_field_test.py
@@ -7,8 +7,7 @@ import torch
 from .. import SemparseTestCase
 from allennlp.data import Vocabulary
 from allennlp.data.token_indexers import SingleIdTokenIndexer, TokenCharactersIndexer
-from allennlp.data.tokenizers import WordTokenizer
-from allennlp.data.tokenizers.word_splitter import SpacyWordSplitter
+from allennlp.data.tokenizers import SpacyTokenizer
 
 from allennlp_semparse.common.wikitables import TableQuestionContext
 from allennlp_semparse.fields import KnowledgeGraphField
@@ -16,7 +15,7 @@ from allennlp_semparse.fields import KnowledgeGraphField
 
 class KnowledgeGraphFieldTest(SemparseTestCase):
     def setUp(self):
-        self.tokenizer = WordTokenizer(SpacyWordSplitter(pos_tags=True))
+        self.tokenizer = SpacyTokenizer()
         self.utterance = self.tokenizer.tokenize("where is mersin?")
         self.token_indexers = {"tokens": SingleIdTokenIndexer("tokens")}
 


### PR DESCRIPTION
- Caught by the AllenNLP Hub build: http://build.allennlp.org/viewLog.html?buildId=21901&buildTypeId=AllenNLPHub_Master&tab=buildLog
- Breakage was introduced in https://github.com/allenai/allennlp/pull/3361. I've jotted this down in the 1.0 release notes.