### PR TITLE
Handling currying of composed functions

### DIFF
--- a/allennlp_semparse/domain_languages/domain_language.py
+++ b/allennlp_semparse/domain_languages/domain_language.py
@@ -1079,26 +1079,28 @@ class DomainLanguage:
 
         elif len(argument_types) == 2:
 
-            def composed_function(
-                arg1: argument_types[0], arg2: argument_types[1]
-            ) -> return_type:  # type:ignore
+            def composed_function(  # type: ignore
+                arg1: argument_types[0], arg2: argument_types[1]  # type:ignore
+            ) -> return_type:  # type: ignore
                 return outer_function(inner_function(arg1, arg2))
 
         elif len(argument_types) == 3:
 
-            def composed_function(
-                arg1: argument_types[0], arg2: argument_types[1], arg3: argument_types[2]
-            ) -> return_type:  # type:ignore
+            def composed_function(  # type:ignore
+                arg1: argument_types[0],  # type: ignore
+                arg2: argument_types[1],  # type: ignore
+                arg3: argument_types[2],  # type:ignore
+            ) -> return_type:  # type: ignore
                 return outer_function(inner_function(arg1, arg2, arg3))
 
         elif len(argument_types) == 4:
 
-            def composed_function(
-                arg1: argument_types[0],
-                arg2: argument_types[1],
-                arg3: argument_types[2],
-                arg4: argument_types[3],
-            ) -> return_type:  # type:ignore
+            def composed_function(  # type:ignore
+                arg1: argument_types[0],  # type:ignore
+                arg2: argument_types[1],  # type:ignore
+                arg3: argument_types[2],  # type:ignore
+                arg4: argument_types[3],  # type:ignore
+            ) -> return_type:  # type: ignore
                 return outer_function(inner_function(arg1, arg2, arg3, arg4))
 
         else:

--- a/allennlp_semparse/domain_languages/domain_language.py
+++ b/allennlp_semparse/domain_languages/domain_language.py
@@ -286,10 +286,16 @@ class DomainLanguage:
     tricky from a modeling perspective.  All of the actual terminal productions in this version
     should have a reasonably strong correspondence with the words in the input utterance.
 
-    In order to perform type inference on curried functions (to know which argument is being
-    ommitted), we currently rely on `executing` the subexpressions.  This should be ok for simple,
-    determinstic languages, but this is very much not recommended for things like NMNs at this
-    point.  We'd need to implement smarter type inference for that to work.
+    Two important notes on currying and composition: first, in order to perform type inference on
+    curried functions (to know which argument is being ommitted), we currently rely on `executing`
+    the subexpressions.  This should be ok for simple, determinstic languages, but this is very much
+    not recommended for things like NMNs at this point.  We'd need to implement smarter type
+    inference for that to work.  Second, the grammar induction that we do for currying and
+    composition is very permissive and quite likely overgenerates productions.  If you use this, you
+    probably should double check all productions that were induced and make sure you really want
+    them in your grammar, manually removing any that you don't want in your subclass after the
+    grammar induction step (i.e., in your constructor, after calling `super().__init__()` and
+    `self.get_nonterminal_productions()`, modify `self._nonterminal_productions` directly).
 
     We have rudimentary support for class hierarchies in the types that you provide.  This is done
     through adding constants multiple times with different types.  For example, say you have a

--- a/tests/domain_languages/domain_language_test.py
+++ b/tests/domain_languages/domain_language_test.py
@@ -215,6 +215,29 @@ class TestDomainLanguage(SemparseTestCase):
         action_sequence = self.curried_language.logical_form_to_action_sequence(logical_form)
         assert self.curried_language.execute_action_sequence(action_sequence) == 10
 
+    def test_currying_composed_functions(self):
+        # Testing all of our operations (conversion and execution) for currying composed functions.
+        logical_form = "(((* sum list3) 1 2) 7)"
+        action_sequence = [
+            "@start@ -> int",
+            "int -> [<int:int>, int]",
+            "<int:int> -> [<int,int,int:int>, int, int]",
+            "<int,int,int:int> -> [*, <List[int]:int>, <int,int,int:List[int]>]",
+            "<List[int]:int> -> sum",
+            "<int,int,int:List[int]> -> list3",
+            "int -> 1",
+            "int -> 2",
+            "int -> 7",
+        ]
+        generated_logical_form = self.curried_language.action_sequence_to_logical_form(action_sequence)
+        assert generated_logical_form == logical_form
+
+        generated_action_sequence = self.curried_language.logical_form_to_action_sequence(logical_form)
+        assert generated_action_sequence == action_sequence
+
+        assert self.curried_language.execute(logical_form) == 10
+        assert self.curried_language.execute_action_sequence(action_sequence) == 10
+
     def test_get_nonterminal_productions(self):
         valid_actions = self.language.get_nonterminal_productions()
         assert set(valid_actions.keys()) == {

--- a/tests/domain_languages/domain_language_test.py
+++ b/tests/domain_languages/domain_language_test.py
@@ -229,10 +229,14 @@ class TestDomainLanguage(SemparseTestCase):
             "int -> 2",
             "int -> 7",
         ]
-        generated_logical_form = self.curried_language.action_sequence_to_logical_form(action_sequence)
+        generated_logical_form = self.curried_language.action_sequence_to_logical_form(
+            action_sequence
+        )
         assert generated_logical_form == logical_form
 
-        generated_action_sequence = self.curried_language.logical_form_to_action_sequence(logical_form)
+        generated_action_sequence = self.curried_language.logical_form_to_action_sequence(
+            logical_form
+        )
         assert generated_action_sequence == action_sequence
 
         assert self.curried_language.execute(logical_form) == 10


### PR DESCRIPTION
My previous improvements to the domain language code added function composition and currying, and handled the case where you want to compose curried functions. It did _not_ handle the case where you want to curry composed functions.  This PR adds that ability (though as of the initial commit, not all tests are passing - there are four main functions that need to support this, and so far only two of them do).

Motivated by the failing tests in #30; this PR checks the same functionality in the main test language, instead of in the NLVR language.  cc @nitishgupta.